### PR TITLE
fix(ci): update Claude workflow permissions

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: read
-      issues: read
+      pull-requests: write
+      issues: write
       id-token: write
       actions: read # Required for Claude to read CI results on PRs
     steps:


### PR DESCRIPTION
## Problem

The Claude Code workflow is failing with `Environment variable validation failed` because it doesn't have write permissions to comment on issues and PRs.

## Solution

Update permissions in `.github/workflows/claude.yml`:
- ✅ `pull-requests: write` (was: read)
- ✅ `issues: write` (was: read)

## Testing

After merge, the workflow will be able to:
- ✅ Comment on issues when mentioned with `@claude`
- ✅ Comment on PRs when mentioned
- ✅ Respond to questions and help with development

## Reference

See error in run: https://github.com/arclabs-studio/ARCUIComponents/actions/runs/21446901507