### PR TITLE
fix(ci): update Claude workflow contents permission

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -19,7 +19,7 @@ jobs:
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       pull-requests: write
       issues: write
       id-token: write


### PR DESCRIPTION
## Problem

Claude can comment on issues but fails when trying to create branches because it lacks write permissions to contents.

## Solution

Update permission in `.github/workflows/claude.yml`:
- ✅ `contents: write` (was: read)

## Testing

After merge, Claude will be able to:
- ✅ Comment on issues (already working)
- ✅ Create branches for implementing fixes
- ✅ Make commits and push changes