### PR TITLE
fix(menu): allow user name to wrap in profile header

### DIFF
--- a/Sources/ARCUIComponents/ARCMenu/Views/ARCMenuUserHeader.swift
+++ b/Sources/ARCUIComponents/ARCMenu/Views/ARCMenuUserHeader.swift
@@ -72,7 +72,7 @@ public struct ARCMenuUserHeader: View {
                         .fontWeight(.semibold)
                         .fontDesign(.rounded)
                         .foregroundStyle(.primary)
-                        .lineLimit(1)
+                        .lineLimit(2)
 
                     if let email = user.email {
                         Text(email)


### PR DESCRIPTION
## Summary
- Change `.lineLimit(1)` to `.lineLimit(2)` in `ARCMenuUserHeader` so long user names wrap to a second line instead of truncating with ellipsis
- Follows Apple HIG pattern (Settings, App Store profile headers use wrapping over scaling)

## Test plan
- [ ] Open menu with a long user name (e.g. "Carlos Rodríguez Asturias") — name should wrap to 2 lines
- [ ] Short names still display on a single line
- [ ] Verify layout with email subtitle and with accent subtitle