### PR TITLE
feat(auth): wire field validation to ARCAuth views [FVRS-134]

### DIFF
--- a/Sources/ARCUIComponents/ARCAuth/ARCForgotPasswordView.swift
+++ b/Sources/ARCUIComponents/ARCAuth/ARCForgotPasswordView.swift
@@ -180,6 +180,8 @@ import SwiftUI
                          configuration: ARCTextFieldConfiguration(inputType: .email,
                                                                   label: emailPlaceholder,
                                                                   leadingIcon: "envelope",
+                                                                  validation: .email,
+                                                                  validateOnChange: true,
                                                                   autocapitalization: .never,
                                                                   autocorrection: false,
                                                                   submitLabel: .send))

--- a/Sources/ARCUIComponents/ARCAuth/ARCSignInView.swift
+++ b/Sources/ARCUIComponents/ARCAuth/ARCSignInView.swift
@@ -191,6 +191,8 @@ import SwiftUI
                          configuration: ARCTextFieldConfiguration(inputType: .email,
                                                                   label: emailPlaceholder,
                                                                   leadingIcon: "envelope",
+                                                                  validation: .email,
+                                                                  validateOnChange: true,
                                                                   autocapitalization: .never,
                                                                   autocorrection: false,
                                                                   submitLabel: .next))

--- a/Sources/ARCUIComponents/ARCAuth/ARCSignUpView.swift
+++ b/Sources/ARCUIComponents/ARCAuth/ARCSignUpView.swift
@@ -161,6 +161,8 @@ import SwiftUI
                          configuration: ARCTextFieldConfiguration(inputType: .email,
                                                                   label: emailPlaceholder,
                                                                   leadingIcon: "envelope",
+                                                                  validation: .email,
+                                                                  validateOnChange: true,
                                                                   autocapitalization: .never,
                                                                   autocorrection: false,
                                                                   submitLabel: .next))
@@ -171,6 +173,7 @@ import SwiftUI
                                                                     label: passwordPlaceholder,
                                                                     leadingIcon: "lock",
                                                                     validation: passwordValidation,
+                                                                    validateOnChange: true,
                                                                     autocapitalization: .never,
                                                                     autocorrection: false,
                                                                     clearButton: .never))


### PR DESCRIPTION
## Summary
- Add `validation: .email` + `validateOnChange: true` to email fields in `ARCSignInView`, `ARCSignUpView`, and `ARCForgotPasswordView`
- Enable `validateOnChange: true` on `ARCSignUpView` password field (already had `.strongPassword`)
- No ViewModel logic changes — package stays pure UI, business validation lives in app domain layer

## Context
Part of FVRS-134 (auth field validation). Companion app-level changes in FavRes-iOS add domain-layer email format validation and wire `.required` to name fields.

## Test plan
- [x] `swift build` passes
- [x] `swift test` passes (465 tests)
- [ ] Manual: Sign In — type invalid email → inline error appears
- [ ] Manual: Sign Up — type invalid email → inline error; type weak password → inline strength errors
- [ ] Manual: Forgot Password — type invalid email → inline error